### PR TITLE
chore(pkg): add repository meta info

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "babel-plugin-transform-es2015-modules-systemjs": "^6.19.0"
   },
   "author": "Guy Bedford",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ModuleLoader/node-es-module-loader"
+  },
   "license": "MIT",
   "devDependencies": {
     "es-module-loader": "^2.0.0",


### PR DESCRIPTION
Hi @guybedford 
Long time no see :)

Just adding repository info so we can have a like to this repo on https://www.npmjs.com/package/node-es-module-loader 

See you :wave: 